### PR TITLE
Fix perl version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@
 language: objective-c
 
 env:
+  matrix:
+    
+    - CONDA_PERL=5.20.3.1
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "T/8QOGCdqPgghRmjCcpenYQBws6j5s9lETkxMjZamuwhboAZgpMPUF5PUQDoCHGNfPfiSwNU7OueSClsnWwFbcpEtMbKj+ZkYyUzN6SAT1Guv2b+vCtEFXzApc2qv0ypDuD2Z49E5E/NO71YkqWydkDTckimGoWJwsM069+T6leWhfgffIowu4YGsBbkbNLByO6ArjY2loXn2jnMUBZMTOfpK0ucZGB1IFnjBJxfQSlNig3nhwX80pE6Ahzse1HCa1M2SGQf5oGJJrSRNRP+6lEqH1lNQCbrYiWcpkRdpsQB/1eLcCHGh6Y1H6vW8jKryj2u5Q3gPIONkEJeuUEvP4xomYvoBTCjYoYN9jl3FArnxB3LAxG11gMJh62ISh6NavDPBILL3f5yV/AbmtyoyWruwFaru27MG0LoCgX1iQR9NpXRjBvUfKTreCbpicHIYZddzIWz+t9RffmncYSRCc1uB/mx05m0ARqE18YdUfTWdjmaAQbuWIYT/ctWW99OV/e51XN3JL1R4buaWVf9TR44WgatylgRO8a5pODYlvD33dxy1ZiAhI/R8WtERXnVzj2dqHycSX7GsmaRxrn4xGUNkp85bldR53CvU9JwQjdBSVrHU1jFFHvg6gSzqBL1ef6tLr9jObTab2egpCKx1BGQd9HDRXvfternwl8EFWg="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -44,6 +44,9 @@ conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).
+    set -x
+    export CONDA_PERL=5.20.3.1
+    set +x
     conda build /recipe_root --quiet || exit 1
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
 
 build:
-    number: 2
+    number: 3
     skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,10 @@ build:
 requirements:
     build:
         - m4
-        - perl >=5.20
+        - perl
     run:
         - m4
-        - perl >=5.20
+        - perl
 
 test:
     commands:


### PR DESCRIPTION
So, this is an instructive lesson for me, but it may be for some of you too (except for @pelson who knows all 😉). After adding `perl` as a dependency, we must run `conda-smithy rerender` to fix the right version of `perl` in the CI scripts. Then we won't need crazy hacks to fix the versioning. 😜 (I did them too 😞)

cc @ocefpaf @msarahan @kmuehlbauer @pelson 