### PR TITLE
Rewrite shebang lines in scripts so conda can understand them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Extensible M4 macros that produce shell scripts to configure software s
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/autoconf-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/autoconf-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/autoconf-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/autoconf-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/version.svg)](https://anaconda.org/conda-forge/autoconf)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/downloads.svg)](https://anaconda.org/conda-forge/autoconf)
+
 Installing autoconf
 ===================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `autoconf` available on your platf
 ```
 conda search autoconf --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/autoconf-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/autoconf-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/autoconf-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/autoconf-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/version.svg)](https://anaconda.org/conda-forge/autoconf)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/downloads.svg)](https://anaconda.org/conda-forge/autoconf)
 
 
 Updating autoconf-feedstock

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,3 +5,12 @@ make
 make check
 make install
 
+# replace shebang lines with #!/$PREFIX/bin/perl
+# as conda does not handle the default shebang lines correctly
+FIRST_LINE="#!${PREFIX}/bin/perl"
+sed -i "1s~.*~${FIRST_LINE}~" $PREFIX/bin/autoheader
+sed -i "1s~.*~${FIRST_LINE}~" $PREFIX/bin/autom4te
+sed -i "1s~.*~${FIRST_LINE}~" $PREFIX/bin/autoreconf
+sed -i "1s~.*~${FIRST_LINE}~" $PREFIX/bin/autoscan
+sed -i "1s~.*~${FIRST_LINE}~" $PREFIX/bin/autoupdate
+sed -i "1s~.*~${FIRST_LINE}~" $PREFIX/bin/ifnames

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
 
 build:
-    number: 3
+    number: 4
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Rewrite the shebang lines in the autoconf scripts without spaces or ending flags so that conda can properly modify them when creating an environment.

Required to work around conda/conda#3999