### PR TITLE
Refresh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root
@@ -34,7 +34,13 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # install conda-build 2.x to build with a long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  # inspect the prefix lengths of the built packages
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/README.md
+++ b/README.md
@@ -3,13 +3,25 @@ About autoconf
 
 Home: http://www.gnu.org/software/autoconf/
 
-Package license: GPL 3
+Package license: GPL-3.0
 
 Feedstock license: BSD 3-Clause
 
 Summary: Extensible M4 macros that produce shell scripts to configure software source code packages.
 
 
+
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/autoconf-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/autoconf-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/autoconf-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/autoconf-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/version.svg)](https://anaconda.org/conda-forge/autoconf)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/downloads.svg)](https://anaconda.org/conda-forge/autoconf)
 
 Installing autoconf
 ===================
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `autoconf` available on your platf
 ```
 conda search autoconf --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/autoconf-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/autoconf-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/autoconf-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/autoconf-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/version.svg)](https://anaconda.org/conda-forge/autoconf)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/autoconf/badges/downloads.svg)](https://anaconda.org/conda-forge/autoconf)
 
 
 Updating autoconf-feedstock

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,10 +41,17 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# install conda-build 2.x to build a long prefix
+conda install --yes --quiet conda-build=2
+conda info
+
 # Embarking on 1 case(s).
     set -x
     export CONDA_PERL=5.20.3.1
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+# inspect the prefix lengths of the built packages
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX PERL='/usr/bin/env perl'
+
 make
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,41 @@
 {% set version = "2.69" %}
 
 package:
-    name: autoconf
-    version: {{ version }}
+  name: autoconf
+  version: {{ version }}
 
 source:
-    fn: autoconf-{{ version }}.tar.gz
-    url: http://ftp.gnu.org/gnu/autoconf/autoconf-{{ version }}.tar.gz
-    sha256: 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+  fn: autoconf-{{ version }}.tar.gz
+  url: http://ftp.gnu.org/gnu/autoconf/autoconf-{{ version }}.tar.gz
+  sha256: 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+  patches:
+    - shebang.patch
 
 build:
-    number: 3
-    skip: True  # [win]
+  number: 4
+  skip: True  # [win]
 
 requirements:
-    build:
-        - m4
-        - perl
-    run:
-        - m4
-        - perl
+  build:
+    - m4
+    - perl
+  run:
+    - m4
+    - perl
 
 test:
-    commands:
-        - autoconf --help
+  commands:
+    - autoconf --help
+    - conda inspect linkages -p $PREFIX autoconf  # [not win]
+    - conda inspect objects -p $PREFIX autoconf  # [osx]
 
 about:
-    home: http://www.gnu.org/software/autoconf/
-    license: GPL 3
-    summary: Extensible M4 macros that produce shell scripts to configure software source code packages.
+  home: http://www.gnu.org/software/autoconf/
+  license: GPL-3.0
+  license_file: COPYING
+  summary: 'Extensible M4 macros that produce shell scripts to configure software source code packages.'
 
 extra:
-    recipe-maintainers:
-        - jakirkham
-        - ocefpaf
+  recipe-maintainers:
+    - jakirkham
+    - ocefpaf

--- a/recipe/shebang.patch
+++ b/recipe/shebang.patch
@@ -1,0 +1,54 @@
+diff -Naur autoconf-2.69.orig/bin/autoheader.in autoconf-2.69/bin/autoheader.in
+--- autoconf-2.69.orig/bin/autoheader.in	2012-04-24 23:37:26.000000000 -0300
++++ autoconf-2.69/bin/autoheader.in	2016-12-08 13:50:07.557236089 -0300
+@@ -1,4 +1,4 @@
+-#! @PERL@
++#!@PERL@
+ # -*- Perl -*-
+ # @configure_input@
+ 
+diff -Naur autoconf-2.69.orig/bin/autom4te.in autoconf-2.69/bin/autom4te.in
+--- autoconf-2.69.orig/bin/autom4te.in	2012-04-24 23:37:26.000000000 -0300
++++ autoconf-2.69/bin/autom4te.in	2016-12-08 13:50:02.397235832 -0300
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#!@PERL@
+ # -*- perl -*-
+ # @configure_input@
+ 
+diff -Naur autoconf-2.69.orig/bin/autoreconf.in autoconf-2.69/bin/autoreconf.in
+--- autoconf-2.69.orig/bin/autoreconf.in	2012-04-24 19:00:28.000000000 -0300
++++ autoconf-2.69/bin/autoreconf.in	2016-12-08 13:49:57.085235567 -0300
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#!@PERL@
+ # -*- perl -*-
+ # @configure_input@
+ 
+diff -Naur autoconf-2.69.orig/bin/autoscan.in autoconf-2.69/bin/autoscan.in
+--- autoconf-2.69.orig/bin/autoscan.in	2012-04-24 23:37:26.000000000 -0300
++++ autoconf-2.69/bin/autoscan.in	2016-12-08 13:49:51.541235291 -0300
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#!@PERL@
+ # -*- perl -*-
+ # @configure_input@
+ 
+diff -Naur autoconf-2.69.orig/bin/autoupdate.in autoconf-2.69/bin/autoupdate.in
+--- autoconf-2.69.orig/bin/autoupdate.in	2012-04-24 23:37:26.000000000 -0300
++++ autoconf-2.69/bin/autoupdate.in	2016-12-08 13:49:45.765235003 -0300
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#!@PERL@
+ # -*- perl -*-
+ # @configure_input@
+ 
+diff -Naur autoconf-2.69.orig/bin/ifnames.in autoconf-2.69/bin/ifnames.in
+--- autoconf-2.69.orig/bin/ifnames.in	2012-04-24 23:37:26.000000000 -0300
++++ autoconf-2.69/bin/ifnames.in	2016-12-08 13:49:39.269234680 -0300
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#!@PERL@
+ # -*- perl -*-
+ # @configure_input@
+ 


### PR DESCRIPTION
@jjhelmus I temporarily activated the `CircleCI` workaround here to test this. I will disable as soon as I am done.

This is an alternative to your #11. It removes the `-w` that, for some reason, makes `conda-build` choke and replaces the shebang with `/usr/bin/env perl` to circumvent issues like https://github.com/conda-forge/texinfo-feedstock/pull/5

This solution is similar to https://github.com/conda-forge/automake-feedstock/commit/f898c00342950e7439393e6e6f1c20b7af4db051 but I prefer the patch as it is clearer, it is right there in the recipe, and easier to drop if a better fix is available.

It all works locally and hopefully this will allow us to move forward with the `conda-build 2` effort.