### PR TITLE
Drop compiler

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,5 +1,3 @@
-c_compiler:
-- toolchain_c
 perl:
 - '5.26'
 pin_run_as_build:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-c_compiler:
-- toolchain_c
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.69" %}
-{% set build = 6 %}
+{% set build = 7 %}
 {% set sha256 = "954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,6 @@ build:
   skip: true  # [win]
 
 requirements:
-  build:
-    - {{ compiler("c") }}
   host:
     - m4
     - perl


### PR DESCRIPTION
Drop the `compiler` syntax from PR ( https://github.com/conda-forge/autoconf-feedstock/pull/17 ) as it is not actually being used to build anything in `autoconf`.